### PR TITLE
hotfix: exclude scrapper download files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# exclude files in scrapper/download/ 
+scrapper/download/*


### PR DESCRIPTION
- scrapping 시 `scrapper/download` 디렉토리 안에 download file들이 생성됩니다. 이를 `.gitignore`를 통해 무시합니다.